### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,6 +95,8 @@ jobs:
   release:
     needs: manifest
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Potential fix for [https://github.com/LockedThread/gtsam_docker/security/code-scanning/4](https://github.com/LockedThread/gtsam_docker/security/code-scanning/4)

In general, the fix is to define an explicit `permissions` block for the `release` job so that `GITHUB_TOKEN` is granted only the minimal privileges that job requires, instead of inheriting potentially broad repository defaults. This aligns the `release` job with the other jobs (`build`, `manifest`, `create-release`) which already specify restricted permissions.

For this specific workflow (`.github/workflows/release.yaml`), we should add a `permissions` section under the `release` job (around line 95–101). The `release` job checks out the repository and invokes `marvinpinto/action-automatic-releases` with `repo_token: "${{ secrets.GITHUB_TOKEN }}"`. That action needs to create or update GitHub Releases, which requires write access to repository contents, so the minimal safe and functional permission is `contents: write`. We don’t see any need for other scopes (like `packages`, `issues`, or `pull-requests`) inside this job, so they should not be granted. Concretely, insert:

```yaml
  release:
    needs: manifest
    runs-on: ubuntu-latest
    permissions:
      contents: write
    steps:
      - uses: actions/checkout@v6
      ...
```

No additional imports, methods, or external dependencies are required; this is a pure YAML configuration change within the shown workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
